### PR TITLE
cli simple as a stick

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ python_jwt
 sseclient
 timeout_decorator
 
+terminaltables
+
 google-api-python-client
 google-cloud-storage
 google-cloud-pubsub

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
             'studio/scripts/studio',
             'studio/scripts/studio-ui',
             'studio/scripts/studio-run',
+            'studio/scripts/studio-runs',
             'studio/scripts/studio-local-worker',
             'studio/scripts/studio-remote-worker',
             'studio/scripts/studio-start-remote-worker',

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -55,13 +55,33 @@ def _list(args, cli_args):
         elif args[0] == 'project':
             assert len(args) == 2
             experiments = db.get_project_experiments(args[1])
+        elif args[0] == 'users':
+            assert len(args) == 1
+            users = db.get_users()
+            for u in users.keys():
+                print users[u].get('email')
+            return 
+        elif args[0] == 'user':
+            assert len(args) == 2
+            users = db.get_users()
+            user_ids = [u for u in users if users[u].get('email') == args[1]]
+            assert len(user_ids) == 1, \
+                'The user with email ' + args[1] + \
+                'not found!'
+            experiments = db.get_user_experiments(user_ids[0])
+        elif args[0] == 'all':
+            assert len(args) == 1
+            users = db.get_users()
+            experiments = []
+            for u in users:
+                experiments += db.get_user_experiments(u)
         else:
             get_logger().critical('Unknown command ' + args[0])
             return
 
     # TODO list experiments of other user or all
 
-    experiments.sort(key=lambda e:e.time_added)
+    experiments.sort(key=lambda e:-e.time_added)
     table = [['Time added', 'Key', 'Project', 'Status']]
 
     for e in experiments:

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -1,0 +1,98 @@
+import logging
+import argparse
+import sys
+import time
+from terminaltables import AsciiTable
+
+from studio import model
+
+logging.basicConfig()
+
+_my_logger = None
+
+def print_help():
+ print('Usage: studio runs [command] arguments')
+ print('\ncommand can be one of the following:')
+ print('')
+ print('\tlist [filter] [username] - display experiments')
+ print('\tstop [experiment] - stop running experiment')
+ print('\tkill [experiment] - stop and delete experiment')
+ print('')
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', help='configuration file', default=None)
+
+    cli_args, script_args = parser.parse_known_args(sys.argv)
+
+    get_logger().setLevel(10)
+ 
+    if len(script_args) < 2:
+        logger.critical('No command provided!')
+        parser.print_help()
+        print_help()
+        return
+
+    cmd = script_args[1]
+    
+    if cmd == 'list':
+        _list(script_args[2:], cli_args)
+    elif cmd == 'stop':
+        _stop(script_args[2:], cli_args)
+    elif cmd == 'kill':
+        _kill(script_args[2:], cli_args)
+
+    else:
+        get_logger().critical('Unknown command ' + cmd)
+        parser.print_help()
+        print_help()
+        return
+
+def _list(args, cli_args):
+    with model.get_db_provider(cli_args.config) as db:
+        if len(args) == 0:
+            experiments = db.get_user_experiments()
+        elif args[0] == 'project':
+            assert len(args) == 2
+            experiments = db.get_project_experiments(args[1])
+        else:
+            get_logger().critical('Unknown command ' + args[0])
+            return
+
+    # TODO list experiments of other user or all
+
+    experiments.sort(key=lambda e:e.time_added)
+    table = [['Time added', 'Key', 'Project', 'Status']]
+
+    for e in experiments:
+        table.append([
+            time.strftime('%Y-%m-%d %H:%M:%S',time.localtime(e.time_added)),
+            e.key, 
+            e.project, 
+            e.status])
+
+    print AsciiTable(table).table
+
+
+def _stop(args, cli_args):
+    with model.get_db_provider(cli_args.config) as db:
+        for e in args:
+            get_logger().info('Stopping experiment ' + e)
+            db.stop_experiment(e)
+
+def _kill(args, cli_args):
+    with model.get_db_provider(cli_args.config) as db:
+        for e in args:
+            get_logger().info('Deleting experiment ' + e)
+            db.delete_experiment(e)
+
+def get_logger():
+    global _my_logger
+    if not _my_logger:
+        _my_logger = logging.getLogger('studio-runs')
+    return _my_logger
+
+
+if __name__ == '__main__':
+    main()
+

--- a/studio/fs_tracker.py
+++ b/studio/fs_tracker.py
@@ -6,7 +6,6 @@ import shutil
 import json
 import re
 
-from model import Experiment
 
 TFSTUDIO_EXPERIMENT = 'TFSTUDIO_EXPERIMENT'
 TFSTUDIO_HOME = 'TFSTUDIO_HOME'
@@ -26,7 +25,7 @@ def get_studio_home():
         return os.path.join(os.path.expanduser('~'), '.tfstudio')
 
 def setup_experiment(env, experiment, clean=True):
-    if isinstance(experiment, Experiment):
+    if not isinstance(experiment, str):
         key = experiment.key
         artifacts = experiment.artifacts
     else:

--- a/studio/scripts/studio
+++ b/studio/scripts/studio
@@ -6,6 +6,7 @@ function print_help {
     echo " "
     echo "  studio ui  -- launches WebUI"
     echo "  studio run -- runs an experiment from a python script"
+    echo "  studio runs -- CLI to view and manipulate existing experiments"
     echo "  studio start remote worker -- orchestrates (re)-starts of worker that listens to the remote queue in a docker container"
     echo "  studio remote worker -- start a worker that listens to remote queue"
     echo "  studio add credentials -- create a docker image with credentials baked in"
@@ -38,6 +39,10 @@ function parse_command {
 case $1 in
     run)
     parse_command "run" $*
+    ;;
+
+    runs)
+    parse_command "runs" $*
     ;;
 
     ui)

--- a/studio/scripts/studio-runs
+++ b/studio/scripts/studio-runs
@@ -1,0 +1,3 @@
+#!python
+from studio import cli
+cli.main()

--- a/studio/tests/model_util_test.py
+++ b/studio/tests/model_util_test.py
@@ -246,7 +246,7 @@ class ModelPipeTest(unittest.TestCase):
 
         pipe = model_util.ModelPipe()
 
-        pipe.add(lambda url: urllib.urlopen(url).read(), num_workers=2)
+        pipe.add(lambda url: urllib.urlopen(url).read(), num_workers=2, timeout=10)
         pipe.add(lambda img: Image.open(BytesIO(img)))
         pipe.add(model_util.resize_to_model_input(model))
         pipe.add(lambda x: 1 - x)
@@ -259,7 +259,8 @@ class ModelPipeTest(unittest.TestCase):
 
         expected_output = {url5: 5, url2: 2}
         output = pipe({url5: url5, url2: url2, urlb: urlb})
-
+        output = {k:v for k,v in output.iteritems() if v}
+        
         self.assertEquals(output, expected_output)
 
 


### PR DESCRIPTION
Per @jasonzliang's request (and as a prelim-passing present :), the CLI to monitor and stop experiments. Basic commands:
  `studio runs list` - shows your experiments
  `studio runs list all` - shows all experiments
  `studio runs list user <user email>` - shows experiments of user with email <user email>
  `studio runs list project <project> ` - shows expeirments in project <project>
  `studio runs stop <experiment>` - stops running experiment
  `studio runs kill <experiments>` - delete experiment

Combine with grep and xargs till the desired effect is reached. For instance:
`studio runs list | grep "running" | awk '{print $5}' | xargs studio runs stop` 
stops running experiments (awk '{print $5}' selects fifth column of the output, which is experiment id)

Known issue - deleting running experiments will NOT stop them; you have to stop them and wait a bit for runners to figure out that experiments are stopped. Normally, 'stopped' flag is checked every 10 seconds, so when network connectivity is ok, stopping, waiting for 30 seconds, and then deleting is sufficient to stop and delete. 

I'll work on fixing that. 