### PR TITLE
endpoint support added for S3 V4 compatability with minio.io and many…

### DIFF
--- a/studio/s3_artifact_store.py
+++ b/studio/s3_artifact_store.py
@@ -15,7 +15,10 @@ class S3ArtifactStore(TartifactStore):
     def __init__(self, config, verbose=10, measure_timestamp_diff=True):
         self.logger = logging.getLogger('S3ArtifactStore')
         self.logger.setLevel(verbose)
-        self.client = boto3.client('s3')
+
+        self.endpoint = config.get("endpoint", "s3-us-west-2.amazonaws.com")
+
+        self.client = boto3.client(service_name='s3', endpoint_url="https://" + self.endpoint)
 
         self.bucket = config['bucket']
         buckets = self.client.list_buckets()
@@ -49,7 +52,7 @@ class S3ArtifactStore(TartifactStore):
             return None
 
     def get_qualified_location(self, key):
-        return 's3://' + self.bucket + '/' + key
+        return 's3://' + self.endpoint + '/' + self.bucket + '/' + key
 
     def get_bucket(self):
         return self.bucket

--- a/studio/tests/artifact_store_test.py
+++ b/studio/tests/artifact_store_test.py
@@ -332,7 +332,7 @@ class S3ArtifactStoreTest(ArtifactStoreTest, unittest.TestCase):
 
     def get_qualified_location_prefix(self):
         store = self.get_store()
-        return "s3://" + store.bucket + "/"
+        return "s3://s3.amazonaws.com/" + store.bucket + "/"
 
 if __name__ == "__main__":
     unittest.main()

--- a/studio/tests/test_config_s3_storage.yaml
+++ b/studio/tests/test_config_s3_storage.yaml
@@ -1,4 +1,4 @@
-database: 
+database:
     type: FireBase
 
     apiKey: AIzaSyCLQbp5X2B4SWzBw-sz9rUnGHNSdMl0Yx8
@@ -12,5 +12,6 @@ database:
  
 storage:
     type: s3
+    endpoint: "s3-us-west-2.amazonaws.com"
     bucket: "studioml-artifacts"
 


### PR DESCRIPTION
… other storage hosting providers public and private

We need to determine how AWS_REGION settings will be defaulted, using a blank value defaults to the us-east-1 region which wont work if buckets are not created in the default s3.amazonaws.com region.