### PR TITLE
Fix endpoint missing from S3 locations, fix quote style

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     keywords='TensorFlow studioml StudioML Studio Keras scikit-learn',
     author='Illia Polosukhin',
     author_email='illia.polosukhin@gmail.com',
-    #        data_files=[('bin', ['studio/scripts/*'])],
+    data_files=[('test_requirements.txt')],
     scripts=[
             'studio/scripts/studio',
             'studio/scripts/studio-ui',

--- a/studio/ec2cloud_worker.py
+++ b/studio/ec2cloud_worker.py
@@ -179,7 +179,7 @@ class EC2WorkerManager(object):
             auth_key = None
             auth_data = None
 
-        credentials = ""
+        credentials = ''
 
         if 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ.keys():
             with open(os.environ['GOOGLE_APPLICATION_CREDENTIALS'], 'r') as f:

--- a/studio/s3_artifact_store.py
+++ b/studio/s3_artifact_store.py
@@ -1,5 +1,6 @@
 import logging
 import calendar
+from urlparse import urlparse
 
 try:
     import boto3
@@ -50,7 +51,8 @@ class S3ArtifactStore(TartifactStore):
             return None
 
     def get_qualified_location(self, key):
-        return 's3://' + self.endpoint + '/' + self.bucket + '/' + key
+        url = urlparse(self.endpoint)
+        return 's3://' + url.netloc + '/' + self.bucket + '/' + key
 
     def get_bucket(self):
         return self.bucket


### PR DESCRIPTION
S3 minio requires the fully qualified host endpoint to work outside of AWS S3 against platforms such as minio and upspin.

Travis tests are passing