### PR TITLE
artifacts from urls

### DIFF
--- a/studio/completion_service/completion_service.py
+++ b/studio/completion_service/completion_service.py
@@ -166,10 +166,13 @@ class CompletionService:
         }
 
         for tag, name in files.iteritems():
-            artifacts[tag] = {
-                'mutable': False,
-                'local': os.path.abspath(os.path.expanduser(name))
-            }
+            url_schema = re.compile('^https{0,1}://')
+            if url_schema.match(name):
+                artifacts[tag]['url'] = name
+            else:
+                artifacts[tag]['local'] = os.path.abspath(
+                    os.path.expanduser(name))
+            artifacts[tag]['mutable'] = False
 
         with open(args_file, 'w') as f:
             f.write(pickle.dumps(args))

--- a/studio/completion_service/completion_service_client.py
+++ b/studio/completion_service/completion_service_client.py
@@ -44,5 +44,6 @@ def main():
     with open(fs_tracker.get_artifact('retval'), 'w') as f:
         f.write(pickle.dumps(retval))
 
+
 if __name__ == "__main__":
     main()

--- a/studio/http_artifact_store.py
+++ b/studio/http_artifact_store.py
@@ -2,6 +2,7 @@ import logging
 import requests
 
 from tartifact_store import TartifactStore
+from util import download_file
 logging.basicConfig()
 
 
@@ -40,18 +41,7 @@ class HTTPArtifactStore(TartifactStore):
             self.logger.error(str(resp.reason))
 
     def _download_file(self, key, local_path):
-
-        response = requests.get(
-            self.url,
-            stream=True)
-
-        if response.status_code == 200:
-            with open(local_path, 'wb') as f:
-                for chunk in response:
-                    f.write(chunk)
-        else:
-            self.logger.info("Response error with code {}"
-                             .format(response.status_code))
+        download_file(self.url, local_path, self.logger)
 
     def _delete_file(self, key):
         raise NotImplementedError

--- a/studio/runner.py
+++ b/studio/runner.py
@@ -639,13 +639,22 @@ def get_experiment_fitnesses(experiments, optimizer, config, logger):
 
 def parse_artifacts(art_list, mutable):
     retval = {}
+    url_schema = re.compile('^https{0,1}://')
     for entry in art_list:
-        path = re.sub(':.*', '', entry)
-        tag = re.sub('.*:', '', entry)
-        retval[tag] = {
-            'local': os.path.expanduser(path),
-            'mutable': mutable
-        }
+        path = re.sub(':[^:]*\Z', '', entry)
+        tag = re.sub('.*:(?=[^:]*\Z)', '', entry)
+        if url_schema.match(entry):
+            assert not mutable, \
+                'artifacts specfied by url can only be immutable'
+            retval[tag] = {
+                'url': path,
+                'mutable': False
+            }
+        else:
+            retval[tag] = {
+                'local': os.path.expanduser(path),
+                'mutable': mutable
+            }
     return retval
 
 

--- a/studio/tests/artifact_store_test.py
+++ b/studio/tests/artifact_store_test.py
@@ -116,7 +116,7 @@ class ArtifactStoreTest(object):
         with open(tar_filename, 'wb') as f:
             f.write(response.content)
 
-        ptar = subprocess.Popen(['tar', '-xzf', tar_filename],
+        ptar = subprocess.Popen(['tar', '-xf', tar_filename],
                                 cwd=tempfile.gettempdir())
 
         tarout, _ = ptar.communicate()

--- a/studio/tests/artifact_store_test.py
+++ b/studio/tests/artifact_store_test.py
@@ -8,6 +8,8 @@ import shutil
 import requests
 import subprocess
 
+from urlparse import urlparse
+
 from studio import model
 from studio.auth import remove_all_keys
 
@@ -333,8 +335,8 @@ class S3ArtifactStoreTest(ArtifactStoreTest, unittest.TestCase):
 
     def get_qualified_location_prefix(self):
         store = self.get_store()
-        endpoint = boto3.client('s3')._endpoint.host
-        return "s3://" + endpoint + "/" + store.bucket + "/"
+        endpoint = urlparse(boto3.client('s3')._endpoint.host)
+        return "s3://" + endpoint.netloc + "/" + store.bucket + "/"
 
 
 if __name__ == "__main__":

--- a/studio/tests/local_worker_test.py
+++ b/studio/tests/local_worker_test.py
@@ -125,6 +125,22 @@ class LocalWorkerTest(unittest.TestCase, QueueTest):
         ):
             pass
 
+    def test_local_worker_co_url(self):
+        expected_str = 'Zabil zaryad ya v pushku tugo'
+        url = 'https://storage.googleapis.com/studio-ed756.appspot.com/' + \
+              'tests/url_artifact.txt'
+
+        with stubtest_worker(
+            self,
+            experiment_name='test_local_worker_co_url' + str(uuid.uuid4()),
+            runner_args=['--capture-once=' + url + ':f'],
+            config_name='test_config.yaml',
+            test_script='art_hello_world.py',
+            script_args=[],
+            expected_output=expected_str
+        ):
+            pass
+
     @unittest.skipIf(keras is None,
                      'keras is required for this test')
     def test_save_get_model(self):

--- a/studio/tests/model_test.py
+++ b/studio/tests/model_test.py
@@ -184,8 +184,9 @@ class FirebaseProviderTest(unittest.TestCase):
                 f.write(random_str)
 
             checkpoint_threads = fb.checkpoint_experiment(experiment)
-            for t in checkpoint_threads:
-                t.join()
+            if checkpoint_threads:
+                for t in checkpoint_threads:
+                    t.join()
 
             shutil.rmtree(modeldir)
             fb.store.get_artifact(

--- a/studio/tests/test_config.yaml
+++ b/studio/tests/test_config.yaml
@@ -15,7 +15,7 @@ log:
     name: output.log
 
 saveWorkspaceFrequencyMinutes: 1 #how often is workspace being saved (minutes)
-verbose: debug
+verbose: error
 
 cloud:
     gcloud:

--- a/studio/util.py
+++ b/studio/util.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import os
 import numpy as np
+import requests
 
 from tensorflow.core.util import event_pb2
 
@@ -206,3 +207,19 @@ class Progbar(object):
 
     def add(self, n, values=None):
         self.update(self.seen_so_far + n, values)
+
+
+def download_file(url, local_path, logger=None):
+    response = requests.get(
+        url,
+        stream=True)
+
+    if response.status_code == 200:
+        with open(local_path, 'wb') as f:
+            for chunk in response:
+                f.write(chunk)
+    else:
+        logger.info("Response error with code {}"
+                    .format(response.status_code))
+
+    return response


### PR DESCRIPTION
The goal is to be able to specify artifacts as a url (@jasonzliang has requested it in context of his ENN experiments, but I think it can be generally useful). 
Implemented in the assumption that artifacts passed that way (that is, via `--capture-once=<url>:<tag>` DO NOT change (are being treated as immutable objects and some caching is done with those assumptions). 

Also, a bunch of little fixes. 