### PR TITLE
GPU images

### DIFF
--- a/studio/completion_service/completion_service.py
+++ b/studio/completion_service/completion_service.py
@@ -145,11 +145,11 @@ class CompletionService:
             else:
                 for i in range(self.num_workers):
                     worker_manager.start_worker(
-                        self.queue_name, 
+                        self.queue_name,
                         self.resources_needed,
                         ssh_keypair=seld.ssh_keypair,
                         timeout=self.cloud_timeout)
-        
+
             self.p = None
         else:
             self.logger.debug('Starting local worker')

--- a/studio/completion_service/completion_service.py
+++ b/studio/completion_service/completion_service.py
@@ -144,10 +144,10 @@ class CompletionService:
                     timeout=self.cloud_timeout)
             else:
                 for i in range(self.num_workers):
-                    worker_manager.start_worker(
+                    self.wm.start_worker(
                         self.queue_name,
                         self.resources_needed,
-                        ssh_keypair=seld.ssh_keypair,
+                        ssh_keypair=self.ssh_keypair,
                         timeout=self.cloud_timeout)
 
             self.p = None

--- a/studio/completion_service/completion_service_test.py
+++ b/studio/completion_service/completion_service_test.py
@@ -97,5 +97,6 @@ class CompletionServiceTest(unittest.TestCase):
 
         self.assertEquals(results, expected_results)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/studio/completion_service/completion_service_test.py
+++ b/studio/completion_service/completion_service_test.py
@@ -50,7 +50,7 @@ class CompletionServiceTest(unittest.TestCase):
         results = {}
         expected_results = {}
         with CompletionService(experimentId,
-                               config=config_path, cloud='gcloud') as cs:
+                               config=config_path, cloud='gcspot') as cs:
             for i in range(0, n_experiments):
                 key = cs.submitTask(
                     os.path.join(
@@ -65,6 +65,37 @@ class CompletionServiceTest(unittest.TestCase):
 
         self.assertEquals(results, expected_results)
 
+    @unittest.skipIf(
+        'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ.keys(),
+        'Need GOOGLE_APPLICATION_CREDENTIALS env variable to' +
+        'use google cloud')
+    def test_two_experiments_gcloud_nonspot(self):
+        experimentId = str(uuid.uuid4())
+        mypath = os.path.dirname(os.path.realpath(__file__))
+        config_path = os.path.join(
+            mypath,
+            '..',
+            'tests',
+            'test_config.yaml')
+
+        n_experiments = 2
+        results = {}
+        expected_results = {}
+        with CompletionService(experimentId,
+                               config=config_path, cloud='gcloud') as cs:
+            for i in range(0, n_experiments):
+                key = cs.submitTask(
+                    os.path.join(
+                        mypath,
+                        'completion_service_func.py'),
+                    [i])
+                expected_results[key] = [i]
+
+            for i in range(0, n_experiments):
+                result = cs.getResults(blocking=True)
+                results[result[0]] = result[1]
+
+        self.assertEquals(results, expected_results)
 
 if __name__ == '__main__':
     unittest.main()

--- a/studio/ec2cloud_worker.py
+++ b/studio/ec2cloud_worker.py
@@ -88,7 +88,7 @@ class EC2WorkerManager(object):
 
     def _get_image_id(self):
         # return 'ami-cd0f5cb6' # vanilla ubuntu 16.04 image
-        return 'ami-eb7d9491' # studio.ml gpu image
+        return 'ami-eb7d9491'  # studio.ml gpu image
 
     def _get_block_device_mappings(self, resources_needed):
         return [{

--- a/studio/ec2cloud_worker.py
+++ b/studio/ec2cloud_worker.py
@@ -87,9 +87,8 @@ class EC2WorkerManager(object):
             self.logger.warn('User startup script argument is deprecated')
 
     def _get_image_id(self):
-        # vanilla ubuntu 16.04 image
-        # return 'ami-d15a75c7'
-        return 'ami-cd0f5cb6'
+        # return 'ami-cd0f5cb6' # vanilla ubuntu 16.04 image
+        return 'ami-eb7d9491' # studio.ml gpu image
 
     def _get_block_device_mappings(self, resources_needed):
         return [{

--- a/studio/gcloud_worker.py
+++ b/studio/gcloud_worker.py
@@ -136,7 +136,12 @@ class GCloudWorkerManager(object):
 
     def _get_instance_config(self, resources_needed, queue_name, timeout=300):
         image_response = self.compute.images().getFromFamily(
-            project='debian-cloud', family='debian-9').execute()
+            project='studio-ed756', family='studioml').execute()
+        
+        if image_response is None:
+            image_response = self.compute.images().getFromFamily(
+                project='debian-cloud', family='debian-9').execute()
+
         source_disk_image = image_response['selfLink']
 
         # Configure the machine

--- a/studio/gcloud_worker.py
+++ b/studio/gcloud_worker.py
@@ -247,7 +247,7 @@ class GCloudWorkerManager(object):
 
             config["scheduling"]['onHostMaintenance'] = "TERMINATE"
             config["automaticRestart"] = True
-  
+
         return config
 
     def _stop_worker(self, worker_id, blocking=True):

--- a/studio/scripts/ec2_worker_startup.sh
+++ b/studio/scripts/ec2_worker_startup.sh
@@ -30,47 +30,50 @@ autoscaling_group="{autoscaling_group}"
 echo "Environment varibles:"
 env
 
-sudo apt -y update
-sudo apt install -y wget python-pip git python-dev jq
-sudo pip install --upgrade pip
-sudo pip install --upgrade awscli boto3
-
-#wget $code_url_base/$code_ver
-#tar -xzf $code_ver
-#cd studio
-git clone $repo_url
-cd studio
-git checkout $branch
-
-if [[ "{use_gpus}" -eq 1 ]]; then
-    cudnn5="libcudnn5_5.1.10-1_cuda8.0_amd64.deb"
-    cudnn6="libcudnn6_6.0.21-1_cuda8.0_amd64.deb"
-    cuda_base="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/"
-    cuda_ver="cuda-repo-ubuntu1604_8.0.61-1_amd64.deb"
-
-    # install cuda
-    wget $cuda_base/$cuda_ver
-    sudo dpkg -i $cuda_ver
+if [ ! -d "studio" ]; then
     sudo apt -y update
-    sudo apt install -y cuda
+    sudo apt install -y wget python-pip git python-dev jq
+    sudo pip install --upgrade pip
+    sudo pip install --upgrade awscli boto3
 
-    # install cudnn
-    wget $code_url_base/$cudnn5
-    wget $code_url_base/$cudnn6
-    sudo dpkg -i $cudnn5
-    sudo dpkg -i $cudnn6
+    #wget $code_url_base/$code_ver
+    #tar -xzf $code_ver
+    #cd studio
+    git clone $repo_url
 
-    sudo pip install tensorflow tensorflow-gpu --upgrade
+    if [[ "{use_gpus}" -eq 1 ]]; then
+        cudnn5="libcudnn5_5.1.10-1_cuda8.0_amd64.deb"
+        cudnn6="libcudnn6_6.0.21-1_cuda8.0_amd64.deb"
+        cuda_base="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/"
+        cuda_ver="cuda-repo-ubuntu1604_8.0.61-1_amd64.deb"
+
+        # install cuda
+        wget $cuda_base/$cuda_ver
+        sudo dpkg -i $cuda_ver
+        sudo apt -y update
+        sudo apt install -y cuda
+
+        # install cudnn
+        wget $code_url_base/$cudnn5
+        wget $code_url_base/$cudnn6
+        sudo dpkg -i $cudnn5
+        sudo dpkg -i $cudnn6
+
+        sudo pip install tensorflow tensorflow-gpu --upgrade
+    else
+        sudo apt-get install default-jre
+    fi
 fi
-sudo apt-get install default-jre
+
+cd studio
+git pull
+git checkout $branch
 sudo pip install -e . --upgrade
 
-mkdir ~/workspace && cd ~/workspace
 studio remote worker --queue=$queue_name  --verbose=debug --timeout={timeout}
 
 # shutdown the instance
 echo "Work done"
-
 
 exit 0
 

--- a/studio/scripts/ec2_worker_startup.sh
+++ b/studio/scripts/ec2_worker_startup.sh
@@ -75,7 +75,11 @@ studio remote worker --queue=$queue_name  --verbose=debug --timeout={timeout}
 # shutdown the instance
 echo "Work done"
 
-exit 0
+if [[ -n $(who) ]]; then
+    echo "Users are logged in, not shutting down"
+    exit 0
+fi
+
 
 
 if [ -n $autoscaling_group ]; then

--- a/studio/scripts/ec2_worker_startup.sh
+++ b/studio/scripts/ec2_worker_startup.sh
@@ -77,6 +77,7 @@ echo "Work done"
 
 if [[ -n $(who) ]]; then
     echo "Users are logged in, not shutting down"
+    echo "Do not forget to shut the instance down manually"
     exit 0
 fi
 

--- a/studio/scripts/gcloud_worker_startup.sh
+++ b/studio/scripts/gcloud_worker_startup.sh
@@ -77,6 +77,12 @@ git checkout $branch
 sudo pip install -e . --upgrade
 studio-remote-worker --queue=$queue_name --verbose=debug --timeout=${timeout}
 
+if [ -n $(who) ]; then
+    echo "Users logged in, preventing auto-shutdown"
+    echo "Do not forget to turn the instance off manually"
+    exit 0
+fi
+
 # shutdown the instance
 not_spot=$(echo "$group_name" | grep "Error 404" | wc -l)
 echo "not_spot = $not_spot"

--- a/studio/scripts/gcloud_worker_startup.sh
+++ b/studio/scripts/gcloud_worker_startup.sh
@@ -77,7 +77,7 @@ git checkout $branch
 sudo pip install -e . --upgrade
 studio-remote-worker --queue=$queue_name --verbose=debug --timeout=${timeout}
 
-if [ -n $(who) ]; then
+if [[ -n $(who) ]]; then
     echo "Users logged in, preventing auto-shutdown"
     echo "Do not forget to turn the instance off manually"
     exit 0

--- a/studio/scripts/gcloud_worker_startup.sh
+++ b/studio/scripts/gcloud_worker_startup.sh
@@ -41,20 +41,21 @@ gac_name=${GOOGLE_APPLICATION_CREDENTIALS##*/}
 repo_url="https://github.com/studioml/studio"
 branch="{studioml_branch}"
 
-sudo apt -y update
-sudo apt install -y wget python-pip git python-dev
 
-git clone $repo_url
+if [ ! -d "studio" ]; then
+    sudo apt -y update
+    sudo apt install -y wget python-pip git python-dev
+    sudo pip install --upgrade pip
+    git clone $repo_url
+fi
+
 cd studio
 git checkout $branch
-#wget $code_url_base/$code_ver
-#tar -xzf $code_ver
-#cd studio
 
-sudo pip install --upgrade pip
 sudo pip install -e . --upgrade
-mkdir ~/workspace && cd ~/workspace
 studio-remote-worker --queue=$queue_name --verbose=debug --timeout=${timeout}
+
+exit 0
 
 # shutdown the instance
 not_spot=$(echo "$group_name" | grep "Error 404" | wc -l)

--- a/studio/tartifact_store.py
+++ b/studio/tartifact_store.py
@@ -274,12 +274,12 @@ class TartifactStore(object):
                 self.logger.warn(
                     'file {} download failed'.format(tar_filename))
 
-        t = Thread(target=finish_download)
-        t.start()
         if background:
+            t = Thread(target=finish_download)
+            t.start()
             return (local_path, t)
         else:
-            t.join()
+            finish_download()
             return local_path
 
     def get_artifact_url(self, artifact, method='GET', get_timestamp=False):


### PR DESCRIPTION
1. Use pre-build gpu images if available
2. GPU workers on GCloud
3. Completion service can use non-spot workers (ec2 and gcloud stand for non-spot, 
gcspot, and ec2spot - for spot)
4. prevent auto-shutdown if user is logged in (useful for debugging)