### PR TITLE
233 fix gpu tf job submission

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ setuptools_scm_git_archive
 configparser
 
 numpy
-tensorflow
 h5py
 pillow
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ terminaltables
 
 google-api-python-client
 google-cloud-storage
-google-cloud-pubsub
+google-cloud-pubsub <= 0.28.3
 google-gax <= 0.15.14
 google-auth-httplib2
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     name='studioml',
     version=VERSION,
     description='TensorFlow model and data management tool',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tensorflow']),
     long_description=read('README.rst'),
     url='https://github.com/studioml/studio',
     license='Apache License, Version 2.0',

--- a/setup.py
+++ b/setup.py
@@ -60,12 +60,12 @@ with open('requirements.txt') as f:
     required = f.read().splitlines()
     # Add the tensorflow python package as a dependency for the studioml
     # python modules but be selective about whether the GPU version is used
-    # or the default CPU version.  Not doing this will result in the CPU 
+    # or the default CPU version.  Not doing this will result in the CPU
     # version taking precedence in many cases.
     try:
         if platform.system() == "Microsoft":
             _libcudart = ctypes.windll.LoadLibrary('cudart.dll')
-        elif platform.system()=="Darwin":
+        elif platform.system() == "Darwin":
             _libcudart = ctypes.cdll.LoadLibrary('libcudart.dylib')
         else:
             _libcudart = ctypes.cdll.LoadLibrary('libcudart.so')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ from setuptools import setup, find_packages
 from subprocess import call
 from setuptools.command.install import install
 from setuptools.command.develop import develop
+
 import sys
+import platform
+import ctypes
 
 VERSION = ""
 
@@ -55,6 +58,20 @@ def read(fname):
 
 with open('requirements.txt') as f:
     required = f.read().splitlines()
+    # Add the tensorflow python package as a dependency for the studioml
+    # python modules but be selective about whether the GPU version is used
+    # or the default CPU version.  Not doing this will result in the CPU 
+    # version taking precedence in many cases.
+    try:
+        if platform.system() == "Microsoft":
+            _libcudart = ctypes.windll.LoadLibrary('cudart.dll')
+        elif platform.system()=="Darwin":
+            _libcudart = ctypes.cdll.LoadLibrary('libcudart.dylib')
+        else:
+            _libcudart = ctypes.cdll.LoadLibrary('libcudart.so')
+        required.append('tensorflow-gpu')
+    except OSError, e:
+        required.append('tensorflow')
 
 with open('test_requirements.txt') as f:
     test_required = f.read().splitlines()

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ with open('requirements.txt') as f:
         else:
             _libcudart = ctypes.cdll.LoadLibrary('libcudart.so')
         required.append('tensorflow-gpu')
-    except OSError, e:
+    except OSError:
         required.append('tensorflow')
 
 with open('test_requirements.txt') as f:

--- a/studio/experiment.py
+++ b/studio/experiment.py
@@ -90,13 +90,13 @@ def create_experiment(
         metric=None):
     key = str(uuid.uuid4()) if not experiment_name else experiment_name
     packages = []
-    for i, pkg in enumerate(pip.pip.get_installed_distributions(local_only=True)):
+    for i, pkg in enumerate(
+            pip.pip.get_installed_distributions(local_only=True)):
         if pkg.key == 'tensorflow':
-            if resources_needed != None:
+            if resources_needed is not None:
                 if int(resources_needed.get('gpus')) > 0:
                     pkg._key = 'tensorflow-gpu'
         packages.append(pkg._key + '==' + pkg._version)
-
 
     return Experiment(
         key=key,

--- a/studio/experiment.py
+++ b/studio/experiment.py
@@ -89,8 +89,14 @@ def create_experiment(
         resources_needed=None,
         metric=None):
     key = str(uuid.uuid4()) if not experiment_name else experiment_name
-    packages = [p._key + '==' + p._version for p in
-                pip.pip.get_installed_distributions(local_only=True)]
+    packages = []
+    for i, pkg in enumerate(pip.pip.get_installed_distributions(local_only=True)):
+        if pkg.key == 'tensorflow':
+            if resources_needed != None:
+                if int(resources_needed.get('gpus')) > 0:
+                    pkg._key = 'tensorflow-gpu'
+        packages.append(pkg._key + '==' + pkg._version)
+
 
     return Experiment(
         key=key,


### PR DESCRIPTION
This change allows the studioml client to changes the dependencies for tensorflow to and from tensorflow-gpu to match the resources needed settings for gpu requirements.

Manual testing passes however it appears that automated tests misbehave because of stale credentials. Comments welcome