### PR TITLE
Custom compression

### DIFF
--- a/studio/apiserver.py
+++ b/studio/apiserver.py
@@ -369,7 +369,7 @@ def add_experiment():
     artifacts = {}
     try:
         experiment = experiment_from_dict(request.json['experiment'])
-        compression = request.json['compression']
+        compression = request.json.get('compression')
         compression = compression if compression else 'bzip2'
 
         if get_db().can_write_experiment(experiment.key, userid):

--- a/studio/apiserver.py
+++ b/studio/apiserver.py
@@ -369,11 +369,15 @@ def add_experiment():
     artifacts = {}
     try:
         experiment = experiment_from_dict(request.json['experiment'])
+        compression = request.json['compression']
+        compression = compression if compression else 'bzip2'
+
         if get_db().can_write_experiment(experiment.key, userid):
             for tag, art in six.iteritems(experiment.artifacts):
                 art.pop('local', None)
 
-            get_db().add_experiment(experiment, userid)
+            get_db().add_experiment(experiment, userid,
+                                    compression=compression)
             added_experiment = get_db().get_experiment(experiment.key)
 
             artifacts = _process_artifacts(added_experiment)

--- a/studio/auth.py
+++ b/studio/auth.py
@@ -5,12 +5,16 @@ import json
 import shutil
 import atexit
 import tempfile
+import logging
+
 try:
     from apscheduler.schedulers.background import BackgroundScheduler
 except BaseException:
     BackgroundScheduler = None
 
 from .util import rand_string
+
+logging.basicConfig()
 
 TOKEN_DIR = os.path.expanduser('~/.studioml/keys')
 HOUR = 3600
@@ -52,6 +56,9 @@ class FirebaseAuth(object):
             blocking=True):
         if not os.path.exists(TOKEN_DIR):
             os.makedirs(TOKEN_DIR)
+
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger.setLevel(logging.DEBUG)
 
         self.firebase = firebase
         self.user = {}
@@ -108,7 +115,8 @@ class FirebaseAuth(object):
                 try:
                     with open(api_key, 'rb') as f:
                         user = json.load(f)
-                except BaseException:
+                except BaseException as e:
+                    logger.info(e)
                     time.sleep(SLEEP_TIME)
                     counter += 1
             if user is None:
@@ -121,7 +129,8 @@ class FirebaseAuth(object):
                     try:
                         self.refresh_token(user['email'], user['refreshToken'])
                         break
-                    except BaseException:
+                    except BaseException as e:
+                        logger.info(e)
                         time.sleep(SLEEP_TIME)
                         counter += 1
             else:

--- a/studio/auth.py
+++ b/studio/auth.py
@@ -116,7 +116,7 @@ class FirebaseAuth(object):
                     with open(api_key, 'rb') as f:
                         user = json.load(f)
                 except BaseException as e:
-                    logger.info(e)
+                    self.logger.info(e)
                     time.sleep(SLEEP_TIME)
                     counter += 1
             if user is None:
@@ -130,7 +130,7 @@ class FirebaseAuth(object):
                         self.refresh_token(user['email'], user['refreshToken'])
                         break
                     except BaseException as e:
-                        logger.info(e)
+                        self.logger.info(e)
                         time.sleep(SLEEP_TIME)
                         counter += 1
             else:

--- a/studio/ec2cloud_worker.py
+++ b/studio/ec2cloud_worker.py
@@ -204,10 +204,10 @@ class EC2WorkerManager(object):
         startup_script = startup_script.format(
             auth_key=auth_key if auth_key else "",
             queue_name=queue_name,
-            auth_data=base64.b64encode(
-                auth_data.encode('utf-8')) if auth_data else "",
+            auth_data=base64.b64encode(auth_data.encode('utf-8'))
+            .decode('utf-8') if auth_data else "",
             google_app_credentials=base64.b64encode(
-                credentials.encode('utf-8')),
+                credentials.encode('utf-8')).decode('utf-8'),
             aws_access_key=self.client._request_signer._credentials.access_key,
             aws_secret_key=self.client._request_signer._credentials.secret_key,
             autoscaling_group=autoscaling_group if autoscaling_group else "",

--- a/studio/firebase_artifact_store.py
+++ b/studio/firebase_artifact_store.py
@@ -16,12 +16,17 @@ class FirebaseArtifactStore(TartifactStore):
     def __init__(self, db_config,
                  measure_timestamp_diff=False,
                  blocking_auth=True,
-                 compression='bzip2',
+                 compression=None,
                  verbose=10):
 
         guest = db_config.get('guest')
 
         self.app = pyrebase.initialize_app(db_config)
+
+        if compression is None:
+            compression = db_config.get('compression')
+        if compression is None:
+            compression = 'bzip2'
 
         self.auth = None
         if not guest and 'serviceAccount' not in db_config.keys():

--- a/studio/firebase_artifact_store.py
+++ b/studio/firebase_artifact_store.py
@@ -25,8 +25,6 @@ class FirebaseArtifactStore(TartifactStore):
 
         if compression is None:
             compression = db_config.get('compression')
-        if compression is None:
-            compression = 'bzip2'
 
         self.auth = None
         if not guest and 'serviceAccount' not in db_config.keys():

--- a/studio/fs_tracker.py
+++ b/studio/fs_tracker.py
@@ -78,7 +78,7 @@ def get_artifact_cache(tag, experiment_name=None):
                 '/[^/]*\Z',
                 '',
                 tag))
-        tag = re.sub('\.tar\.[^\.]*\Z', '', re.sub('.*/', '', tag))
+        tag = re.sub('\.tar\.?[^\.]*\Z', '', re.sub('.*/', '', tag))
 
     if tag.startswith('blobstore/'):
         return get_blob_cache(tag)

--- a/studio/fs_tracker.py
+++ b/studio/fs_tracker.py
@@ -102,7 +102,7 @@ def get_blob_cache(blobkey):
     if not os.path.exists(blobcache_dir):
         os.makedirs(blobcache_dir)
 
-    blobkey = re.sub('\.tar\.[^\.]*\Z', '', blobkey)
+    blobkey = re.sub('\.tar\.?[^\.]*\Z', '', blobkey)
     if blobkey.startswith('blobstore/'):
         blobkey = re.sub('.*/', '', blobkey)
 

--- a/studio/gcloud_artifact_store.py
+++ b/studio/gcloud_artifact_store.py
@@ -19,10 +19,7 @@ class GCloudArtifactStore(TartifactStore):
 
         self.config = config
 
-        if compression is None:
-            compression = config.get('compression')
-        if compression is None:
-            compression = 'bzip2'
+        compression = compression if compression else config.get('compression')
 
         super(GCloudArtifactStore, self).__init__(
             measure_timestamp_diff,

--- a/studio/gcloud_artifact_store.py
+++ b/studio/gcloud_artifact_store.py
@@ -11,13 +11,18 @@ logging.basicConfig()
 class GCloudArtifactStore(TartifactStore):
     def __init__(self, config,
                  measure_timestamp_diff=False,
-                 compression='bzip2',
+                 compression=None,
                  verbose=10):
 
         self.logger = logging.getLogger('GCloudArtifactStore')
         self.logger.setLevel(verbose)
 
         self.config = config
+
+        if compression is None:
+            compression = config.get('compression')
+        if compression is None:
+            compression = 'bzip2'
 
         super(GCloudArtifactStore, self).__init__(
             measure_timestamp_diff,

--- a/studio/http_artifact_store.py
+++ b/studio/http_artifact_store.py
@@ -7,14 +7,21 @@ logging.basicConfig()
 
 
 class HTTPArtifactStore(TartifactStore):
-    def __init__(self, url, timestamp=None, verbose=10):
+    def __init__(self, url,
+                 timestamp=None,
+                 compression=None,
+                 verbose=logging.DEBUG):
+
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.setLevel(verbose)
 
         self.url = url
         self.timestamp = timestamp
 
-        super(HTTPArtifactStore, self).__init__(False)
+        super(HTTPArtifactStore, self).__init__(
+            False,
+            compression=compression,
+            verbose=verbose)
     '''
     def _upload_file(self, key, local_path):
         with open(local_path, 'rb') as f:

--- a/studio/http_provider.py
+++ b/studio/http_provider.py
@@ -40,8 +40,6 @@ class HTTPProvider(object):
         self.compression = compression
         if self.compression is None:
             self.compression = config.get('compression')
-        if self.compression is None:
-            self.compression = 'bzip2'
 
     def add_experiment(self, experiment, userid=None,
                        compression=None):

--- a/studio/http_provider.py
+++ b/studio/http_provider.py
@@ -15,7 +15,12 @@ logging.basicConfig()
 class HTTPProvider(object):
     """Data provider communicating with API server."""
 
-    def __init__(self, config, verbose=10, blocking_auth=True):
+    def __init__(
+            self,
+            config,
+            verbose=10,
+            blocking_auth=True,
+            compression=None):
         # TODO: implement connection
         self.url = config.get('serverUrl')
         self.verbose = verbose
@@ -32,18 +37,33 @@ class HTTPProvider(object):
                                  config.get("password"),
                                  blocking_auth)
 
-    def add_experiment(self, experiment):
+        self.compression = compression
+        if self.compression is None:
+            self.compression = config.get('compression')
+        if self.compression is None:
+            self.compression = 'bzip2'
+
+    def add_experiment(self, experiment, userid=None,
+                       compression=None):
+
         headers = self._get_headers()
+        compression = compression if compression else self.compression
 
         for tag, art in six.iteritems(experiment.artifacts):
             if not art['mutable'] and art.get('local') is not None:
-                art['hash'] = HTTPArtifactStore(None, None, self.verbose) \
+                art['hash'] = HTTPArtifactStore(None, None,
+                                                compression,
+                                                self.verbose) \
                     .get_artifact_hash(art)
+
+        data = {}
+        data['experiment'] = experiment.__dict__
+        data['compression'] = compression
 
         request = requests.post(
             self.url + '/api/add_experiment',
             headers=headers,
-            data=json.dumps({"experiment": experiment.__dict__}))
+            data=json.dumps(data))
 
         self._raise_detailed_error(request)
         artifacts = request.json()['artifacts']
@@ -63,7 +83,8 @@ class HTTPProvider(object):
 
                 HTTPArtifactStore(target_art['url'],
                                   target_art['timestamp'],
-                                  self.verbose) \
+                                  compression=self.compression,
+                                  verbose=self.verbose) \
                     .put_artifact(art)
 
     def delete_experiment(self, experiment):

--- a/studio/keyvalue_provider.py
+++ b/studio/keyvalue_provider.py
@@ -22,7 +22,7 @@ class KeyValueProvider(object):
             blocking_auth=True,
             verbose=10,
             store=None,
-            compression='bzip2'):
+            compression=None):
         guest = db_config.get('guest')
 
         self.app = pyrebase.initialize_app(db_config)
@@ -50,6 +50,8 @@ class KeyValueProvider(object):
 
         self.max_keys = db_config.get('max_keys', 100)
         self.compression = compression
+        if self.compression is None:
+            self.compression = db_config.get('compression')
 
     def _get_userid(self):
         userid = None
@@ -85,10 +87,8 @@ class KeyValueProvider(object):
         for tag, art in six.iteritems(experiment.artifacts):
             if art['mutable']:
                 art['key'] = self._get_experiments_keybase() + \
-                    experiment.key + '/' + tag + '.tar'
-                if compression:
-                    art['key'] = art['key'] + '.' + compression
-
+                    experiment.key + '/' + tag + '.tar' + \
+                    util.compression_to_extension(compression)[0]
             else:
                 if 'local' in art.keys():
                     # upload immutable artifacts

--- a/studio/keyvalue_provider.py
+++ b/studio/keyvalue_provider.py
@@ -88,7 +88,7 @@ class KeyValueProvider(object):
             if art['mutable']:
                 art['key'] = self._get_experiments_keybase() + \
                     experiment.key + '/' + tag + '.tar' + \
-                    util.compression_to_extension(compression)[0]
+                    util.compression_to_extension(compression)
             else:
                 if 'local' in art.keys():
                     # upload immutable artifacts

--- a/studio/s3_artifact_store.py
+++ b/studio/s3_artifact_store.py
@@ -19,7 +19,7 @@ class S3ArtifactStore(TartifactStore):
     def __init__(self, config,
                  verbose=10,
                  measure_timestamp_diff=False,
-                 compression='bzip2'):
+                 compression=None):
         self.logger = logging.getLogger('S3ArtifactStore')
         self.logger.setLevel(verbose)
 
@@ -29,6 +29,11 @@ class S3ArtifactStore(TartifactStore):
             aws_secret_access_key=config.get('aws_secret_key'),
             endpoint_url=config.get('endpoint'),
             region_name=config.get('region'))
+
+        if compression is None:
+            compression = config.get('compression')
+        if compression is None:
+            compression = 'bzip2'
 
         self.endpoint = self.client._endpoint.host
 

--- a/studio/s3_artifact_store.py
+++ b/studio/s3_artifact_store.py
@@ -32,8 +32,6 @@ class S3ArtifactStore(TartifactStore):
 
         if compression is None:
             compression = config.get('compression')
-        if compression is None:
-            compression = 'bzip2'
 
         self.endpoint = self.client._endpoint.host
 

--- a/studio/util.py
+++ b/studio/util.py
@@ -273,6 +273,14 @@ def retry(f,
 
 
 def compression_to_extension(compression):
+    return _compression_to_extension_taropt(compression)[0]
+
+
+def compression_to_taropt(compression):
+    return _compression_to_extension_taropt(compression)[1]
+
+
+def _compression_to_extension_taropt(compression):
     default_compression = 'none'
     if compression is None:
         compression = default_compression

--- a/studio/util.py
+++ b/studio/util.py
@@ -270,3 +270,32 @@ def retry(f,
                      'sleeping {}s and retrying (attempt {} of {})')
                     .format(e, sleeptime, i, no_retries))
             time.sleep(sleeptime)
+
+
+def compression_to_extension(compression):
+    default_compression = 'none'
+    if compression is None:
+        compression = default_compression
+
+    compression = compression.lower()
+
+    if compression == 'bzip2':
+        return '.bz2', '--bzip2'
+
+    elif compression == 'gzip':
+        return '.gz', '--gzip'
+
+    elif compression == 'xz':
+        return '.xz', '--xz'
+
+    elif compression == 'lzma':
+        return '.lzma', '--lzma'
+
+    elif compression == 'lzop':
+        return '.lzop', '--lzop'
+
+    elif compression == 'none':
+        return '', ''
+
+    raise ValueError('Unknown compression method {}'
+                     .format(compression))


### PR DESCRIPTION
The goal is to make artifact compression customizable. We were using bzip2 (it provides good compression ratio and is determenistic - i.e. the same file compressed twice has the same hash, which is important for caching of artifacts), but for large files / directories it may be slow. One can either use faster compression methods (i.e. lzop - but it is non-determenistic), or disable compression altogether. 