### PR TITLE
skip git repo test

### DIFF
--- a/studio/tests/git_util_test.py
+++ b/studio/tests/git_util_test.py
@@ -22,6 +22,8 @@ class GitUtilTest(unittest.TestCase):
         os.remove(filename)
         self.assertFalse(is_clean)
 
+    @unittest.skipIf(os.environ.get('TEST_GIT_REPO_ADDRESS') != 1,
+                     'skip if being tested from a forked repo')
     def test_repo_url(self):
         expected = re.compile(
             'https{0,1}://github\.com/studioml/studio(\.git){0,1}')


### PR DESCRIPTION
Skip git repo address tests unless a environment flag TEST_GIT_REPO_ADDRESS is set - to be able to test forked repos