### PR TITLE
Add an error and stop if a user specified config file was not found, …

### DIFF
--- a/studio/model.py
+++ b/studio/model.py
@@ -25,6 +25,9 @@ def get_config(config_file=None):
 
     config_paths = []
     if config_file:
+        if not os.path.exists(config_file):
+            raise ValueError('User config file {} not found'
+                             .format(config_file))
         config_paths.append(os.path.expanduser(config_file))
 
     config_paths.append(os.path.expanduser('~/.studioml/config.yaml'))


### PR DESCRIPTION
…dont try defaults as that is not the intent of the user