### PR TITLE
changed serverURL to use http

### DIFF
--- a/studio/default_config.yaml
+++ b/studio/default_config.yaml
@@ -1,6 +1,6 @@
 database:
     type: http
-    serverUrl: https://zoo.studio.ml
+    serverUrl: http://zoo.studio.ml
     authentication: github
             
 storage:


### PR DESCRIPTION
Fixed the SSL certificate error authenticating to zoo.studio.ml by changing the serverURL under "database" section to http://zoo.studio.ml