### PR TITLE
pika version bump tested manually onsite for python 2.6 and 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,6 @@ rsa==3.4.2
 awscli
 filelock
 pygtail
-pika == 0.11.2
+pika == 0.12.0
 
 cachetools == 2.0.1


### PR DESCRIPTION
We need to bump the pika library being used to avoid a deprecated interface issue for python 3.7.

https://github.com/pika/pika/issues/921

Will have Jason review and leave the branch open for any comments.

Thanks