### PR TITLE
Fixes to allow use of Minio service as S3 API storage/database endpoint.

### DIFF
--- a/studio/base_artifact_store.py
+++ b/studio/base_artifact_store.py
@@ -1,0 +1,11 @@
+class BaseArtifactStore(object):
+
+    def __init__(self):
+        self.storage_client = None
+
+    def set_storage_client(self, sclient):
+        self.storage_client = sclient
+
+    def get_storage_client(self):
+        return self.storage_client
+

--- a/studio/http_provider.py
+++ b/studio/http_provider.py
@@ -4,7 +4,7 @@ import six
 import time
 import re
 
-from . import pyrebase, logs
+from . import logs
 from .auth import get_auth
 from .http_artifact_store import HTTPArtifactStore
 from .experiment import experiment_from_dict
@@ -27,7 +27,6 @@ class HTTPProvider(object):
         self.logger.setLevel(self.verbose)
 
         self.auth = None
-        self.app = pyrebase.initialize_app(config)
         guest = config.get('guest')
         if not guest and 'serviceAccount' not in config.keys():
             self.auth = get_auth(

--- a/studio/keyvalue_provider.py
+++ b/studio/keyvalue_provider.py
@@ -424,6 +424,9 @@ class KeyValueProvider(object):
         if existing_email != email:
             self._set(keypath, email)
 
+    def get_artifact_store(self):
+        return self.store
+
     def __enter__(self):
         return self
 

--- a/studio/keyvalue_provider.py
+++ b/studio/keyvalue_provider.py
@@ -4,7 +4,7 @@ import six
 import re
 from threading import Thread
 
-from . import util, git_util, pyrebase, logs
+from . import util, git_util, logs
 from .firebase_artifact_store import FirebaseArtifactStore
 from .auth import get_auth
 from .experiment import experiment_from_dict
@@ -24,7 +24,6 @@ class KeyValueProvider(object):
             compression=None):
         guest = db_config.get('guest')
 
-        self.app = pyrebase.initialize_app(db_config)
         self.logger = logs.getLogger(self.__class__.__name__)
         self.logger.setLevel(verbose)
 
@@ -429,7 +428,5 @@ class KeyValueProvider(object):
         return self
 
     def __exit__(self, *args):
-        if self.app:
-            self.app.requests.close()
         if self.store:
             self.store.__exit__()

--- a/studio/model.py
+++ b/studio/model.py
@@ -16,10 +16,8 @@ from .http_provider import HTTPProvider
 from .firebase_provider import FirebaseProvider
 from .s3_provider import S3Provider
 from .gs_provider import GSProvider
+from .model_setup import setup_model
 from . import logs
-
-DB_KEY = "database"
-STORE_KEY = "store"
 
 def get_config(config_file=None):
 
@@ -57,10 +55,6 @@ def get_config(config_file=None):
 
     raise ValueError('None of the config paths {} exits!'
                      .format(config_paths))
-
-# Global dictionary which keeps Database Provider
-# and Artifact Store objects created from experiment configuration.
-_model_setup = None
 
 def get_db_provider(config=None, blocking_auth=True):
     if not config:
@@ -112,20 +106,8 @@ def get_db_provider(config=None, blocking_auth=True):
         _model_setup = None
         raise ValueError('Unknown type of the database ' + db_config['type'])
 
-    _model_setup = { DB_KEY: db_provider, STORE_KEY: artifact_store }
+    setup_model(db_provider, artifact_store)
     return db_provider
-
-
-def get_db_provider():
-    if _model_setup is None:
-        return None
-    return _model_setup.get(DB_KEY, None)
-
-def get_artifact_store():
-    if _model_setup is None:
-        return None
-    return _model_setup.get(STORE_KEY, None)
-
 
 def parse_verbosity(verbosity=None):
     if verbosity is None:

--- a/studio/model_setup.py
+++ b/studio/model_setup.py
@@ -1,0 +1,20 @@
+
+DB_KEY = "database"
+STORE_KEY = "store"
+
+# Global dictionary which keeps Database Provider
+# and Artifact Store objects created from experiment configuration.
+_model_setup = None
+
+def setup_model(db_provider, artifact_store):
+    _model_setup = { DB_KEY: db_provider, STORE_KEY: artifact_store }
+
+def get_db_provider():
+    if _model_setup is None:
+        return None
+    return _model_setup.get(DB_KEY, None)
+
+def get_artifact_store():
+    if _model_setup is None:
+        return None
+    return _model_setup.get(STORE_KEY, None)

--- a/studio/s3_artifact_store.py
+++ b/studio/s3_artifact_store.py
@@ -13,7 +13,6 @@ except ImportError:
 from .tartifact_store import TartifactStore
 from . import logs
 
-
 class S3ArtifactStore(TartifactStore):
     def __init__(self, config,
                  verbose=10,
@@ -38,11 +37,13 @@ class S3ArtifactStore(TartifactStore):
             self.client.create_bucket(
                 Bucket=self.bucket
             )
-
         super(S3ArtifactStore, self).__init__(
             measure_timestamp_diff,
             compression=compression,
             verbose=verbose)
+
+        self.set_storage_client(self.client)
+
 
     def _upload_file(self, key, local_path):
         self.client.upload_file(local_path, self.bucket, key)
@@ -89,6 +90,3 @@ class S3ArtifactStore(TartifactStore):
 
     def get_bucket(self):
         return self.bucket
-
-    def get_s3_client(self):
-        return self.client

--- a/studio/s3_artifact_store.py
+++ b/studio/s3_artifact_store.py
@@ -89,3 +89,6 @@ class S3ArtifactStore(TartifactStore):
 
     def get_bucket(self):
         return self.bucket
+
+    def get_s3_client(self):
+        return self.client

--- a/studio/tartifact_store.py
+++ b/studio/tartifact_store.py
@@ -244,10 +244,12 @@ class TartifactStore(object):
                 listtar = listtar.strip().split(b'\n')
                 listtar = [s.decode('utf-8') for s in listtar]
 
+                isTarFromDotDir = False
                 self.logger.info('List of files in the tar: ' + str(listtar))
                 if listtar[0].startswith('./'):
                     # Files are archived into tar from .; adjust path
                     # accordingly
+                    isTarFromDotDir = True
                     basepath = local_path
                 else:
                     basepath = local_basepath
@@ -274,7 +276,10 @@ class TartifactStore(object):
                     self.logger.info('tar stdout output: \n ' + str(tarout))
                     self.logger.info('tar stderr output: \n ' + str(tarerr))
 
-                if len(listtar) == 1:
+                if len(listtar) == 1 and not isTarFromDotDir:
+                    # Here we protect ourselves from the corner case,
+                    # when we try to move A/. folder to A.
+                    # os.rename() will fail to do that.
                     actual_path = os.path.join(basepath, listtar[0])
                     self.logger.info(
                         'Renaming {} into {}'.format(

--- a/studio/tartifact_store.py
+++ b/studio/tartifact_store.py
@@ -21,11 +21,16 @@ from .util import download_file, download_file_from_qualified, retry
 from .util import compression_to_extension, compression_to_taropt, timeit
 from .util import sixdecode
 
+from .base_artifact_store import BaseArtifactStore
 
-class TartifactStore(object):
+
+class TartifactStore(BaseArtifactStore):
 
     def __init__(self, measure_timestamp_diff=False, compression=None,
                  verbose=logs.DEBUG):
+
+        super(TartifactStore, self).__init__()
+
         if measure_timestamp_diff:
             try:
                 self.timestamp_shift = self._measure_timestamp_diff()

--- a/studio/util.py
+++ b/studio/util.py
@@ -328,8 +328,9 @@ def download_file_from_qualified(qualified, local_path, logger=None):
 
 def _get_active_s3_client():
     artifact_store = model_setup.get_artifact_store()
-    if artifact_store is None:
-        raise NotImplementedError("Artifact store is not set up")
+    if artifact_store is None \
+        or not isinstance(artifact_store, BaseArtifactStore):
+        raise NotImplementedError("Artifact store is not set up or has the wrong type")
 
     storage_client = ((BaseArtifactStore)(artifact_store)).get_storage_client()
     if storage_client is None:


### PR DESCRIPTION
Fixes #381 
Several small fixes for bugs that prevented use of Minio service endpoints
as storage/database option in studioml configuration.
Along the way I had to address a circular import dependency
which popped up when trying to use correct boto3 client for our S3 API connection
to Minio.
