### PR TITLE
Adjust S3 service endpoints syntax.

### DIFF
--- a/studio/s3_artifact_store.py
+++ b/studio/s3_artifact_store.py
@@ -11,6 +11,7 @@ except ImportError:
     boto3 = None
 
 from .tartifact_store import TartifactStore
+from .util import adjust_s3_endpoint_url
 from . import logs
 
 class S3ArtifactStore(TartifactStore):
@@ -18,11 +19,12 @@ class S3ArtifactStore(TartifactStore):
                  verbose=10,
                  measure_timestamp_diff=False,
                  compression=None):
+        store_endpoint_url = adjust_s3_endpoint_url(config.get('endpoint'))
         self.client = boto3.client(
             's3',
             aws_access_key_id=config.get('aws_access_key'),
             aws_secret_access_key=config.get('aws_secret_key'),
-            endpoint_url=config.get('endpoint'),
+            endpoint_url=store_endpoint_url,
             region_name=config.get('region'))
 
         if compression is None:

--- a/studio/util.py
+++ b/studio/util.py
@@ -388,6 +388,13 @@ def _s3_download_dir(bucket, dist, local, logger=None):
 def has_aws_credentials():
     return _get_active_s3_client()._request_signer._credentials is not None
 
+def adjust_s3_endpoint_url(endpoint_url):
+    if endpoint_url is None:
+        return None
+    if not isinstance(endpoint_url, str):
+        return endpoint_url
+    if endpoint_url.startswith("s3://"):
+        return endpoint_url.replace("s3://", "http://", 1)
 
 def retry(f,
           no_retries=5, sleep_time=1,


### PR DESCRIPTION
Fix for part of issue 397.
Adjust s3 service URL endpoints
for experiment database and storage specifications
to start with "http://" instead of "s3://"
