### PR TITLE
Fix LocalQueue handling for "deleted" state.

### DIFF
--- a/studio/local_queue.py
+++ b/studio/local_queue.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from . import fs_tracker, logs
 import uuid
 import glob
@@ -9,7 +10,6 @@ _local_queue_lock = filelock.FileLock(
     os.path.expanduser('~/.studioml/local_queue.lock')
 )
 
-
 class LocalQueue:
     def __init__(self, path=None, verbose=10):
         if path is None:
@@ -18,9 +18,35 @@ class LocalQueue:
             self.path = path
         self.logger = logs.getLogger(self.__class__.__name__)
         self.logger.setLevel(verbose)
+        self.status_marker = os.path.join(self.path, 'is_active.queue')
+        try:
+            with open(self.status_marker, "w") as sm:
+                pass
+        except IOError as error:
+            self.logger.error('FAILED to create {0} for LocalQueue. ABORTING.'
+                              .format(self.status_marker))
+            sys.exit(-1)
+
+    def _get_queue_status(self):
+        with _local_queue_lock:
+            files = glob.glob(self.path + '/*')
+            if files is None:
+                files = list()
+        is_active = self.status_marker in files
+        try:
+            files.remove(self.status_marker)
+        except:
+            # Ignore possible exception:
+            # we just want list of files without status marker
+            pass
+
+        print(">>>> Status: " + str(is_active) + "  [" + repr(files) + ']')
+
+        return is_active, files
 
     def has_next(self):
-        return any(glob.glob(self.path + '/*'))
+        is_active, files = self._get_queue_status()
+        return is_active and len(files) > 0
 
     def clean(self, timeout=0):
         while self.has_next():
@@ -28,13 +54,19 @@ class LocalQueue:
 
     # Delete and clean are the same for local queue
     def delete(self):
+        print("LOCAL QUEUE CLEAN")
         self.clean()
+        with _local_queue_lock:
+            os.remove(self.status_marker)
+        print("LOCAL QUEUE CLEAN DONE")
 
     def dequeue(self, acknowledge=True, timeout=0):
         wait_step = 1
         for waited in range(0, timeout + wait_step, wait_step):
             with _local_queue_lock:
-                files = glob.glob(self.path + '/*')
+                is_active, files = self._get_queue_status()
+                if not is_active:
+                    return None
                 if any(files):
                     first_file = min([(p, os.path.getmtime(p)) for p in files],
                                      key=lambda t: t[1])[0]
@@ -54,6 +86,7 @@ class LocalQueue:
             # self.logger.info(
             #    ('No messages found, sleeping for {} ' +
             #     ' (total sleep time {})').format(wait_step, waited))
+            print('No messages found, sleeping for {0} ({1}) '.format(wait_step, waited))
             time.sleep(wait_step)
 
     def enqueue(self, data):
@@ -75,8 +108,9 @@ class LocalQueue:
         return 'local'
 
     def shutdown(self, delete_queue=True):
+        print("LOCAL QUEUE SHUTDOWN")
         self.delete()
-
+        print("LOCAL QUEUE SHUTDOWN DONE")
 
 def get_local_queue_lock():
     return _local_queue_lock

--- a/studio/local_queue.py
+++ b/studio/local_queue.py
@@ -39,9 +39,6 @@ class LocalQueue:
             # Ignore possible exception:
             # we just want list of files without status marker
             pass
-
-        print(">>>> Status: " + str(is_active) + "  [" + repr(files) + ']')
-
         return is_active, files
 
     def has_next(self):
@@ -54,11 +51,9 @@ class LocalQueue:
 
     # Delete and clean are the same for local queue
     def delete(self):
-        print("LOCAL QUEUE CLEAN")
         self.clean()
         with _local_queue_lock:
             os.remove(self.status_marker)
-        print("LOCAL QUEUE CLEAN DONE")
 
     def dequeue(self, acknowledge=True, timeout=0):
         wait_step = 1
@@ -86,7 +81,6 @@ class LocalQueue:
             # self.logger.info(
             #    ('No messages found, sleeping for {} ' +
             #     ' (total sleep time {})').format(wait_step, waited))
-            print('No messages found, sleeping for {0} ({1}) '.format(wait_step, waited))
             time.sleep(wait_step)
 
     def enqueue(self, data):
@@ -108,9 +102,7 @@ class LocalQueue:
         return 'local'
 
     def shutdown(self, delete_queue=True):
-        print("LOCAL QUEUE SHUTDOWN")
         self.delete()
-        print("LOCAL QUEUE SHUTDOWN DONE")
 
 def get_local_queue_lock():
     return _local_queue_lock

--- a/studio/local_worker.py
+++ b/studio/local_worker.py
@@ -163,9 +163,12 @@ class LocalExecutor(object):
                     minutes=minutes)
 
                 def kill_if_stopped():
-                    db_expr = db.get_experiment(
-                        experiment.key,
-                        getinfo=False)
+                    try:
+                        db_expr = db.get_experiment(
+                            experiment.key,
+                            getinfo=False)
+                    except:
+                        db_expr = None
 
                     # Transient issues with getting experiment data might
                     # result in a None value being returned, as result


### PR DESCRIPTION
Fixes #407 

For local tasks queue which is implemented as file folder,
we add special "marker" file to indicate that queue is currently active.
Deleting this marker signals queue deletion for watching worker process
and its proper shutdown in turn.
