### PR TITLE
Remove @timeit method decorators.

### DIFF
--- a/studio/gs_provider.py
+++ b/studio/gs_provider.py
@@ -19,7 +19,6 @@ class GSProvider(KeyValueProvider):
             verbose,
             store)
 
-    @timeit
     def _get(self, key, shallow=False):
         bucket = self.meta_store._get_bucket_obj()
         retval = {}

--- a/studio/keyvalue_provider.py
+++ b/studio/keyvalue_provider.py
@@ -254,7 +254,6 @@ class KeyValueProvider(object):
         else:
             return checkpoint_threads
 
-    @timeit
     def _get_experiment_info(self, experiment):
         info = {}
         type_found = False
@@ -291,7 +290,6 @@ class KeyValueProvider(object):
 
         return info
 
-    @timeit
     def _get_experiment_logtail(self, experiment):
         try:
             tarf = self.store.stream_artifact(experiment.artifacts['output'])
@@ -309,7 +307,6 @@ class KeyValueProvider(object):
                               .format(repr(e)))
             return None
 
-    @timeit
     def get_experiment(self, key, getinfo=True):
         data = self._get(self._get_experiments_keybase() + key)
         if data is None:

--- a/studio/tartifact_store.py
+++ b/studio/tartifact_store.py
@@ -308,7 +308,6 @@ class TartifactStore(BaseArtifactStore):
             finish_download()
             return local_path
 
-    @timeit
     def get_artifact_url(self, artifact, method='GET', get_timestamp=False):
         if 'key' in artifact.keys():
             url = self._get_file_url(artifact['key'], method=method)
@@ -334,7 +333,6 @@ class TartifactStore(BaseArtifactStore):
         if 'key' in artifact.keys():
             self._delete_file(artifact['key'])
 
-    @timeit
     def stream_artifact(self, artifact):
         url = self.get_artifact_url(artifact)
         if url is None:


### PR DESCRIPTION
Fixes #425
Get rid of @timeit decorators
to reduce logging spewage.