### PR TITLE
Fixes for studioml S3 storage providers.

### DIFF
--- a/studio/experiment_submitter.py
+++ b/studio/experiment_submitter.py
@@ -34,6 +34,12 @@ def submit_experiments(
     for experiment in experiments:
         experiment.pythonenv = model.add_packages(experiment.pythonenv, python_pkg)
 
+    # Reset our model setup, which will guarantee
+    # that we rebuild our database and storage provider objects
+    # that's important in the case that previous experiment batch
+    # cleaned up after itself.
+    model.reset_model_providers()
+
     # Now add them to experiments database:
     try:
         with model.get_db_provider(config) as db:

--- a/studio/model.py
+++ b/studio/model.py
@@ -21,7 +21,7 @@ from .qclient_cache import get_cached_queue, shutdown_cached_queue
 from .util import parse_verbosity
 from .auth import get_auth
 
-from .model_setup import setup_model, get_model_db_provider
+from .model_setup import setup_model, get_model_db_provider, reset_model
 from . import logs
 
 def get_config(config_file=None):
@@ -60,6 +60,9 @@ def get_config(config_file=None):
 
     raise ValueError('None of the config paths {} exits!'
                      .format(config_paths))
+
+def reset_model_providers():
+    reset_model()
 
 def get_db_provider(config=None, blocking_auth=True):
 

--- a/studio/model_setup.py
+++ b/studio/model_setup.py
@@ -21,3 +21,8 @@ def get_model_artifact_store():
     if _model_setup is None:
         return None
     return _model_setup.get(STORE_KEY, None)
+
+def reset_model():
+    global _model_setup
+    _model_setup = None
+

--- a/studio/s3_provider.py
+++ b/studio/s3_provider.py
@@ -52,6 +52,8 @@ class S3Provider(KeyValueProvider):
             return suffixes
 
     def _delete(self, key):
+        self.logger.error("S3 PROVIDER DELETE object: {0} {1}".format(self.bucket, key))
+
         response = self.meta_store.client.delete_object(
             Bucket=self.bucket,
             Key=key)

--- a/studio/s3_provider.py
+++ b/studio/s3_provider.py
@@ -52,7 +52,7 @@ class S3Provider(KeyValueProvider):
             return suffixes
 
     def _delete(self, key):
-        self.logger.error("S3 PROVIDER DELETE object: {0} {1}".format(self.bucket, key))
+        self.logger.info("S3 deleting object: {0}/{1}".format(self.bucket, key))
 
         response = self.meta_store.client.delete_object(
             Bucket=self.bucket,


### PR DESCRIPTION
Fixes #434
Additional fixes covering the case when S3 buckets for experiment storage and database
are deleted as part of post-experiment clean-up.

