### PR TITLE
Added explicit default values to config.get(...) queries.

### DIFF
--- a/studio/apiserver.py
+++ b/studio/apiserver.py
@@ -579,7 +579,7 @@ def main(args=sys.argv[1:]):
     _config = config
     _db_provider = model.get_db_provider(_config)
 
-    getlogger().setLevel(parse_verbosity(config.get('verbose')))
+    getlogger().setLevel(parse_verbosity(config.get('verbose', None)))
 
     global _save_auth_cookie
     _save_auth_cookie = True

--- a/studio/auth.py
+++ b/studio/auth.py
@@ -249,8 +249,8 @@ class FirebaseAuth(object):
         self.user = {}
         self.use_email_auth = config.get('use_email_auth', False)
         if self.use_email_auth:
-            self.email = config.get('email')
-            self.password = config.get('password')
+            self.email = config.get('email', None)
+            self.password = config.get('password', None)
             if not self.password or not self.email:
                 self.email = input(
                     'Firebase token is not found or expired! ' +

--- a/studio/db_providers/db_provider_setup.py
+++ b/studio/db_providers/db_provider_setup.py
@@ -73,7 +73,7 @@ def get_db_provider(config=None, blocking_auth=True):
 
     if config is None:
         config = get_config()
-    verbose = parse_verbosity(config.get('verbose'))
+    verbose = parse_verbosity(config.get('verbose', None))
 
     # Save this verbosity level as global for the whole experiment job:
     set_storage_verbose_level(verbose)

--- a/studio/firebase_storage_handler.py
+++ b/studio/firebase_storage_handler.py
@@ -21,12 +21,12 @@ class FirebaseStorageHandler(StorageHandler):
         self.logger = logs.get_logger(self.__class__.__name__)
         self.logger.setLevel(verbose)
 
-        guest = db_config.get('guest')
+        guest = db_config.get('guest', None)
 
         self.app = pyrebase.initialize_app(db_config)
 
         if compression is None:
-            compression = db_config.get('compression')
+            compression = db_config.get('compression', None)
 
         self.auth = None
         if not guest and 'serviceAccount' not in db_config.keys():

--- a/studio/http_provider.py
+++ b/studio/http_provider.py
@@ -22,7 +22,7 @@ class HTTPProvider(object):
             blocking_auth=True,
             compression=None):
         # TODO: implement connection
-        self.url = config.get('serverUrl')
+        self.url = config.get('serverUrl', None)
         self.verbose = get_storage_verbose_level()
         self.logger = logs.get_logger('HTTPProvider')
         self.logger.setLevel(self.verbose)
@@ -36,16 +36,16 @@ class HTTPProvider(object):
             compression=compression)
 
         self.auth = None
-        guest = config.get('guest')
+        guest = config.get('guest', None)
         if not guest and 'serviceAccount' not in config.keys():
             self.auth = get_auth(
-                config.get('authentication'),
+                config.get('authentication', None),
                 blocking_auth
             )
 
         self.compression = compression
         if self.compression is None:
-            self.compression = config.get('compression')
+            self.compression = config.get('compression', None)
 
     def add_experiment(self, experiment, userid=None,
                        compression=None):

--- a/studio/local_worker.py
+++ b/studio/local_worker.py
@@ -34,7 +34,7 @@ class LocalExecutor(object):
 
         self.task_queue = queue
         self.logger = logs.get_logger('LocalExecutor')
-        self.logger.setLevel(model.parse_verbosity(self.config.get('verbose')))
+        self.logger.setLevel(model.parse_verbosity(self.config.get('verbose', None)))
         self.logger.debug("Config: ")
         self.logger.debug(self.config)
 
@@ -320,7 +320,7 @@ def worker_loop(queue, parsed_args,
         if verbose:
             config['verbose'] = verbose
         else:
-            verbose = model.parse_verbosity(config.get('verbose'))
+            verbose = model.parse_verbosity(config.get('verbose', None))
 
         logger.setLevel(verbose)
 
@@ -342,12 +342,12 @@ def worker_loop(queue, parsed_args,
                 sleep_time=10,
                 logger=logger)
 
-            if config.get('experimentLifetime') and \
+            if config.get('experimentLifetime', None) and \
                 int(str2duration(config['experimentLifetime'])
                     .total_seconds()) + experiment.time_added < time.time():
                 logger.info(
                     'Experiment expired (max lifetime of {0} was exceeded)'
-                    .format(config.get('experimentLifetime'))
+                    .format(config.get('experimentLifetime', None))
                 )
                 queue.acknowledge(ack_key)
                 continue

--- a/studio/model.py
+++ b/studio/model.py
@@ -31,7 +31,7 @@ def get_db_provider(config=None, blocking_auth=True):
 
     if config is None:
         config = get_config()
-    verbose = parse_verbosity(config.get('verbose'))
+    verbose = parse_verbosity(config.get('verbose', None))
 
     # Save this verbosity level as global for the whole experiment job:
     set_storage_verbose_level(verbose)

--- a/studio/pyrebase.py
+++ b/studio/pyrebase.py
@@ -53,13 +53,13 @@ class Firebase:
     """ Firebase Interface """
 
     def __init__(self, config):
-        self.api_key = config.get("apiKey")
-        self.auth_domain = config.get("authDomain")
-        self.database_url = config.get("databaseURL")
-        self.storage_bucket = config.get("storageBucket")
+        self.api_key = config.get("apiKey", None)
+        self.auth_domain = config.get("authDomain", None)
+        self.database_url = config.get("databaseURL", None)
+        self.storage_bucket = config.get("storageBucket", None)
         self.credentials = None
         self.requests = requests.Session()
-        if config.get("serviceAccount"):
+        if config.get("serviceAccount", None):
             scopes = [
                 'https://www.googleapis.com/auth/firebase.database',
                 'https://www.googleapis.com/auth/userinfo.email',

--- a/studio/runner.py
+++ b/studio/runner.py
@@ -722,7 +722,7 @@ def _parse_hardware(runner_args, config={}):
     parse_list = ['gpus', 'cpus', 'ram', 'hdd', 'gpuMem']
     for key in parse_list:
         from_args = runner_args.__dict__.get(key)
-        from_config = config.get(key)
+        from_config = config.get(key, None)
         if from_args is not None:
             resources_needed[key] = from_args
         elif from_config is not None:

--- a/studio/storage/local_storage_handler.py
+++ b/studio/storage/local_storage_handler.py
@@ -17,7 +17,7 @@ class LocalStorageHandler(StorageHandler):
         self.logger.setLevel(get_storage_verbose_level())
 
         if compression is None:
-            compression = config.get('compression')
+            compression = config.get('compression', None)
 
         self.endpoint = config.get('endpoint', '~')
         self.endpoint = os.path.realpath(os.path.expanduser(self.endpoint))


### PR DESCRIPTION
This is done  to avoid potential exceptions in case our "configuration" object
is not standard Python dictionary, but a class instance generated (for example)
by Hocon parser.
 